### PR TITLE
Modernize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,21 @@
-pam_propperpwnam.so: pam_propperpwnam.c
-	$(CC) -shared -fPIC -o pam_propperpwnam.so pam_propperpwnam.c -lpam
+CFLAGS ?= -Wall -O2 -fPIC
+LDFLAGS ?= -shared
+LDLIBS ?= -lpam
+DESTDIR ?=
+INSTALL ?= install -D -p -o root -g root -m 644
+SECUREDIR ?= /lib/security
 
-.PHONY: clean
+.PHONY: all clean install
+
+.SUFFIXES: .c .so
+
+.c.so:
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+all: pam_propperpwnam.so
 
 clean:
-	rm *.o *.so
+	-rm *.so
 
 install: pam_propperpwnam.so
-	install -o root -g root -m 644 pam_propperpwnam.so /lib/security/
-
+	$(INSTALL) $< $(DESTDIR)$(SECUREDIR)/$<

--- a/README
+++ b/README
@@ -1,24 +1,24 @@
 pam_propperpwnam
 
-A PAM module that uses the entered login name as key to
-query the password database configured through nsswitch.conf
+This PAM module uses the entered login name as a key to query
+the password database configured through nsswitch.conf
 and replaces the login name with what has been returned.
 
-On the typical system this module performs an identity transform.
+On the typical system this module performs an identity transformation.
 The main usage scenario are systems in networks where a user name
 is used in several distinct authentication systems, some of them
-being case sensitive and others not. For example the mail system
+being case sensitive and others not. For example, the mail system
 may do case insensitive username lookups, while the workstations
-are case sensitive. In such environments users are often puzzeled
-about a username working in one situation does not work in another.
+are case sensitive. In such environments users are often puzzled
+when a username working in one situation does not work in another.
 
-Actually this module has been written for this very reason.
+Actually, this module has been written for this very reason.
 
 CONFIGURATION
 
 pam_propperpwnam.so needs no configuration except adding it as "optional"
-early in in the list of PAM modules executed for user authentication.
-A good place in most distributions is /etc/pam.d/common-auth
+early in the list of PAM modules executed for user authentication.
+A good place in most distributions is /etc/pam.d/common-auth file.
 
 Example configuration, authentication with rewritten username against
 Kerberos5 infrastructure:

--- a/pam_propperpwnam.c
+++ b/pam_propperpwnam.c
@@ -30,12 +30,12 @@
 *
 *******************************************************************************
 *
-* a PAM module that sets the user loginname to the username
-* stored in the user databased using the loginname passed
-* as access key.
+* This PAM module sets the user login name to the username
+* stored in the user database using the login name passed
+* as an access key.
 *
 * Example usage scenario is adjusting the usernames' characters
-* case in  environments where case sensitive and case insensitive
+* case in environments where case sensitive and case insensitive
 * services are mixed (the module was initially developed for
 * this very usage scenario).
 */

--- a/pam_propperpwnam.c
+++ b/pam_propperpwnam.c
@@ -41,7 +41,8 @@
 */
 
 #include <stdlib.h>
-#include <sys/types.h>
+#include <string.h>
+#include <syslog.h>
 #include <unistd.h>
 #include <pwd.h>
 
@@ -52,10 +53,14 @@
 #define PAM_SM_AUTH
 
 #include <security/pam_modules.h>
-#include <security/_pam_macros.h>
+#include <security/pam_modutil.h>
+#include <security/pam_ext.h>
 
-PAM_EXTERN int
-pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, const char **argv)
+PAM_EXTERN int pam_sm_setcred(
+	pam_handle_t *pamh,
+	int flags,
+	int argc,
+	char const *argv[] )
 {
 	return PAM_SUCCESS;
 }
@@ -66,53 +71,34 @@ PAM_EXTERN int pam_sm_authenticate(
 	int argc,
 	char const *argv[] )
 {
-	int error;
-	char *entered_username;
-
-	struct passwd pwd;
-	struct passwd *pwd_result;
-	char *pwd_buf;
-	size_t pwd_bufsize;
+	const char *username;
+	struct passwd *pw;
 
 #if DEBUG
 	fprintf(stderr, "pam_propperpwnam called\n");
 #endif
 
-	error = pam_get_user(pamh, (char const **)&entered_username, 0);
-	if(PAM_SUCCESS != error)
+	if( pam_get_user(pamh, &username, 0) != PAM_SUCCESS ) {
+		pam_syslog(pamh, LOG_NOTICE, "cannot determine user name");
 		return PAM_USER_UNKNOWN;
-
-#if DEBUG	
-	fprintf(stderr, "pam_propperpwnam entered username is %s\n", entered_username);
-#endif
-
-	pwd_bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
-	if( -1 == pwd_bufsize )          /* Value was indeterminate */
-		pwd_bufsize = 16384;        /* Should be more than enough */
-
-	pwd_buf = malloc( pwd_bufsize );
-	if( !pwd_buf ) {
-		return PAM_AUTH_ERR;
 	}
 
-	error = getpwnam_r(entered_username, &pwd, pwd_buf, pwd_bufsize, &pwd_result);
-	if( !pwd_result ) {
-		free(pwd_buf);
-		if( !error )
-			return PAM_USER_UNKNOWN;
-		return PAM_AUTH_ERR;
+#if DEBUG	
+	fprintf(stderr, "pam_propperpwnam entered username is %s\n", username);
+#endif
+
+	pw = pam_modutil_getpwnam(pamh, username);
+	if( !pw ) {
+		pam_syslog(pamh, LOG_NOTICE, "User unknown");
+		return PAM_USER_UNKNOWN;
 	}
 
 #if DEBUG
-	fprintf(stderr, "pam_propperpwnam propper username is %s\n", pwd_result->pw_name);
+	fprintf(stderr, "pam_propperpwnam propper username is %s\n", pw->pw_name);
 #endif
 
-	error = pam_set_item(pamh, PAM_USER, pwd_result->pw_name);
-	free( pwd_buf );
-	if( PAM_SUCCESS != error ) {
-		return PAM_AUTH_ERR;
-	}
+	if( strcmp(username, pw->pw_name) != 0 )
+	       return pam_set_item(pamh, PAM_USER, pw->pw_name);
 
 	return PAM_SUCCESS;
 }
-


### PR DESCRIPTION
Parametrize Makefile so it can be used in various build systems without modifications.
Make use of pam_modutil_getpwnam() and pam_syslog() functions introduced in Linux-PAM back in 2005.